### PR TITLE
QA-12432: Wait for custom handler to be available when we need it

### DIFF
--- a/src/main/java/org/apache/felix/fileinstall/internal/DirectoryWatcher.java
+++ b/src/main/java/org/apache/felix/fileinstall/internal/DirectoryWatcher.java
@@ -128,6 +128,7 @@ public class DirectoryWatcher extends Thread implements BundleListener
     private Bundle systemBundle;
     String originatingFileName;
     boolean noInitialDelay;
+    boolean firstRun = true;
     int startLevel;
     int activeLevel;
     boolean updateWithListeners;
@@ -233,8 +234,9 @@ public class DirectoryWatcher extends Thread implements BundleListener
 
     public void start()
     {
-        if (noInitialDelay)
-        {
+        if (handlerTracker != null && handlerTracker.getService() == null) {
+            log(Logger.LOG_INFO, "Starting directory watcher for " + watchedDirectory + " , custom handler service is not available, will wait", null);
+        } else if (noInitialDelay) {
             log(Logger.LOG_DEBUG, "Starting initial scan", null);
             initializeCurrentManagedBundles();
             Set<File> files = scanner.scan(true);
@@ -251,10 +253,6 @@ public class DirectoryWatcher extends Thread implements BundleListener
             }
         }
         super.start();
-        CustomHandler customHandler = getCustomHandler();
-        if (customHandler != null) {
-            customHandler.watcherStarted();
-        }
     }
 
     /**
@@ -296,6 +294,9 @@ public class DirectoryWatcher extends Thread implements BundleListener
                             + poll + " milliseconds for initial directory scan.", e);
                     return;
                 }
+            }
+
+            if (firstRun) {
                 initializeCurrentManagedBundles();
             }
         }
@@ -310,7 +311,7 @@ public class DirectoryWatcher extends Thread implements BundleListener
                 // Don't access the disk when the framework is still in a startup phase.
                 if (startLevelSvc.getStartLevel() >= activeLevel
                         && systemBundle.getState() == Bundle.ACTIVE) {
-                    Set<File> files = scanner.scan(false);
+                    Set<File> files = scanner.scan(firstRun);
                     // Check that there is a result.  If not, this means that the directory can not be listed,
                     // so it's presumably not a valid directory (it may have been deleted by someone).
                     // In such case, just sleep
@@ -390,6 +391,14 @@ public class DirectoryWatcher extends Thread implements BundleListener
         finally
         {
             fileInstall.lock.readLock().unlock();
+        }
+
+        if (firstRun) {
+            CustomHandler customHandler = getCustomHandler();
+            if (customHandler != null) {
+                customHandler.watcherStarted();
+            }
+            firstRun = false;
         }
     }
 
@@ -1532,7 +1541,21 @@ public class DirectoryWatcher extends Thread implements BundleListener
 
 
     private CustomHandler getCustomHandler() {
-        return handlerTracker != null ? handlerTracker.getService() : null;
+        if (handlerTracker == null) {
+            return null;
+        }
+        CustomHandler service = handlerTracker.getService();
+        if (service != null) {
+            return service;
+        }
+        log(Logger.LOG_INFO, "Waiting for custom handler for " + watchedDirectory, null);
+        try {
+            return handlerTracker.waitForService(0);
+        } catch (InterruptedException e) {
+            log(Logger.LOG_DEBUG, "Watcher for " + watchedDirectory + " was interrupted while waiting for custom handler"
+                    + poll + " milliseconds for initial directory scan.", e);
+            return null;
+        }
     }
 
     private void registerCustomHandlerHandler(String handlerFilter) {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-12432

## Description

- Delay init and scan in watcher thread if the service is not available at initial startup
- Correctly call watcherStarted in all cases, even if it was delayed
- Always wait for the handler to be available when it is configured